### PR TITLE
Don't update config when user cancels file/folder dialogs

### DIFF
--- a/win/CS/HandBrakeWPF/ViewModels/ChaptersViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/ChaptersViewModel.cs
@@ -104,8 +104,8 @@ namespace HandBrakeWPF.ViewModels
                     DefaultExt = "csv",
                     CheckPathExists = true
                 };
-            saveFileDialog.ShowDialog();
-            if (!string.IsNullOrEmpty(saveFileDialog.FileName))
+            bool? dialogResult = saveFileDialog.ShowDialog();
+            if (dialogResult.HasValue && dialogResult.Value && !string.IsNullOrEmpty(saveFileDialog.FileName))
             {
                 this.ExportChaptersToCSV(saveFileDialog.FileName);
             }
@@ -153,10 +153,10 @@ namespace HandBrakeWPF.ViewModels
         public void Import()
         {
             var dialog = new OpenFileDialog { Filter = "CSV files (*.csv)|*.csv", CheckFileExists = true };
-            dialog.ShowDialog();
+            bool? dialogResult  = dialog.ShowDialog();
             string filename = dialog.FileName;
 
-            if (string.IsNullOrEmpty(filename))
+            if (!dialogResult.HasValue || !dialogResult.Value || string.IsNullOrEmpty(filename))
             {
                 return;
             }

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1491,11 +1491,14 @@ namespace HandBrakeWPF.ViewModels
         public void FolderScan()
         {
             VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog { Description = Resources.Main_PleaseSelectFolder, UseDescriptionForTitle = true };
-            dialog.ShowDialog();
+            bool? dialogResult = dialog.ShowDialog();
 
-            ShowSourceSelection = false;
+            if (dialogResult.HasValue && dialogResult.Value)
+            {
+                ShowSourceSelection = false;
 
-            this.StartScan(dialog.SelectedPath, this.TitleSpecificScan);
+                this.StartScan(dialog.SelectedPath, this.TitleSpecificScan);
+            }
         }
 
         /// <summary>
@@ -1504,11 +1507,14 @@ namespace HandBrakeWPF.ViewModels
         public void FileScan()
         {
             OpenFileDialog dialog = new OpenFileDialog { Filter = "All files (*.*)|*.*" };
-            dialog.ShowDialog();
+            bool? dialogResult = dialog.ShowDialog();
 
-            ShowSourceSelection = false;
+            if (dialogResult.HasValue && dialogResult.Value)
+            {
+                ShowSourceSelection = false;
 
-            this.StartScan(dialog.FileName, this.TitleSpecificScan);
+                this.StartScan(dialog.FileName, this.TitleSpecificScan);
+            }
         }
 
         /// <summary>
@@ -1849,9 +1855,12 @@ namespace HandBrakeWPF.ViewModels
         public void PresetImport()
         {
             OpenFileDialog dialog = new OpenFileDialog { Filter = "Preset Files|*.json;*.plist", CheckFileExists = true };
-            dialog.ShowDialog();
-            this.presetService.Import(dialog.FileName);
-            this.NotifyOfPropertyChange(() => this.Presets);
+            bool? dialogResult = dialog.ShowDialog();
+            if (dialogResult.HasValue && dialogResult.Value)
+            {
+                this.presetService.Import(dialog.FileName);
+                this.NotifyOfPropertyChange(() => this.Presets);
+            }
         }
 
         /// <summary>

--- a/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
@@ -1221,10 +1221,13 @@ namespace HandBrakeWPF.ViewModels
         /// </summary>
         public void BrowseSendFileTo()
         {
-            VistaOpenFileDialog dialog = new VistaOpenFileDialog { Filter = "All files (*.*)|*.*" };
-            dialog.ShowDialog();
-            this.SendFileTo = Path.GetFileNameWithoutExtension(dialog.FileName);
-            this.sendFileToPath = dialog.FileName;
+            VistaOpenFileDialog dialog = new VistaOpenFileDialog { Filter = "All files (*.*)|*.*", FileName = this.sendFileToPath };
+            bool? dialogResult = dialog.ShowDialog();
+            if (dialogResult.HasValue && dialogResult.Value)
+            {
+                this.SendFileTo = Path.GetFileNameWithoutExtension(dialog.FileName);
+                this.sendFileToPath = dialog.FileName;
+            }
         }
 
         /// <summary>
@@ -1232,9 +1235,12 @@ namespace HandBrakeWPF.ViewModels
         /// </summary>
         public void BrowseAutoNamePath()
         {
-            VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog { Description = "Please select a folder.", UseDescriptionForTitle = true };
-            dialog.ShowDialog();
-            this.AutoNameDefaultPath = dialog.SelectedPath;
+            VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog { Description = "Please select a folder.", UseDescriptionForTitle = true, SelectedPath = this.AutoNameDefaultPath };
+            bool? dialogResult = dialog.ShowDialog();
+            if (dialogResult.HasValue && dialogResult.Value)
+            {
+                this.AutoNameDefaultPath = dialog.SelectedPath;
+            }
         }
 
         /// <summary>
@@ -1242,9 +1248,12 @@ namespace HandBrakeWPF.ViewModels
         /// </summary>
         public void BrowseVlcPath()
         {
-            VistaOpenFileDialog dialog = new VistaOpenFileDialog { Filter = "All files (*.exe)|*.exe" };
-            dialog.ShowDialog();
-            this.VLCPath = dialog.FileName;
+            VistaOpenFileDialog dialog = new VistaOpenFileDialog { Filter = "All files (*.exe)|*.exe", FileName = this.VLCPath };
+            bool? dialogResult = dialog.ShowDialog();
+            if (dialogResult.HasValue && dialogResult.Value)
+            {
+                this.VLCPath = dialog.FileName;
+            }
         }
 
         /// <summary>
@@ -1252,9 +1261,12 @@ namespace HandBrakeWPF.ViewModels
         /// </summary>
         public void BrowseLogPath()
         {
-            VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog { Description = "Please select a folder.", UseDescriptionForTitle = true };
-            dialog.ShowDialog();
-            this.LogDirectory = dialog.SelectedPath;
+            VistaFolderBrowserDialog dialog = new VistaFolderBrowserDialog { Description = "Please select a folder.", UseDescriptionForTitle = true, SelectedPath = this.LogDirectory };
+            bool? dialogResult = dialog.ShowDialog();
+            if (dialogResult.HasValue && dialogResult.Value)
+            {
+                this.LogDirectory = dialog.SelectedPath;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Most invocations of file or folder dialogs do not check if the user cancelled the dialog. Also, they do no populate the dialog with the current selection. This patch fixes that.